### PR TITLE
perf: fire-wall + shake + renderer residuals (follow-up to #8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ tests/perf/results/*
 # the optimisations from REPORT.md are implemented and validated.
 # Posted as a PR comment via gh — intentionally NOT committed.
 /IMPROVEMENTS.md
+
+# Follow-up improvements report from the fire-wall / shake / renderer
+# residuals perf PR (companion to IMPROVEMENTS.md). Posted as a PR
+# comment via gh — intentionally NOT committed.
+/IMPROVEMENTS-2.md

--- a/lua/power-mode/fire_wall.lua
+++ b/lua/power-mode/fire_wall.lua
@@ -63,6 +63,52 @@ local fire_hl_groups = {
   { name = "PowerModeFire5", threshold = 25,  fg = "#884400", ctermfg = 94  },  -- dim ember
 }
 
+-- Precomputed heat-value lookup tables (REPORT R1 / F3). Replaces the
+-- per-cell linear walks of heat_chars / fire_hl_groups (5 entries each)
+-- that used to run *three times per cell per frame* (row builder twice
+-- + highlight loop). Built once at module load against the heat_chars
+-- and fire_hl_groups thresholds defined above.
+local heat_char_lut = {}      -- [0..255] -> single-cell string
+local heat_hl_lut = {}        -- [0..255] -> highlight group name
+local heat_charlen_lut = {}   -- [0..255] -> #char in bytes
+-- "Live" threshold mirrors grid_has_heat() (heat > 5). live_lut[h] is
+-- 1 when the cell is considered live, 0 otherwise. Used by the F4
+-- incremental live_cells counter without an extra branch per write.
+local heat_live_lut = {}      -- [0..255] -> 0 or 1
+
+local function build_heat_luts()
+  for h = 0, 255 do
+    local ch = " "
+    for _, entry in ipairs(heat_chars) do
+      if h >= entry.threshold then ch = entry.char; break end
+    end
+    local hl = "PowerModeFireBg"
+    for _, g in ipairs(fire_hl_groups) do
+      if h >= g.threshold then hl = g.name; break end
+    end
+    heat_char_lut[h] = ch
+    heat_hl_lut[h] = hl
+    heat_charlen_lut[h] = #ch
+    heat_live_lut[h] = (h > 5) and 1 or 0
+  end
+end
+build_heat_luts()
+
+-- F4: live-cell counter. Number of grid cells with heat > 5. Updated
+-- incrementally on every write into `grid` (seed, propagate, bottom-
+-- cool). Replaces the O(w·h) grid_has_heat() scan with an O(1) check
+-- in the cooldown branch, and lets us assert "no live heat ⇒ nothing
+-- to render" without touching the grid.
+local live_cells = 0
+
+-- Scratch list of highlight runs collected during the render walk and
+-- consumed *after* nvim_buf_set_lines (extmarks must reference lines
+-- that already exist in the buffer). Flat layout to keep allocation
+-- cost at zero: index i ∈ {0,4,8,...} stores row, start_col, end_col,
+-- hl_group for one run. F2 RLE batching.
+local scratch_runs = {}
+local scratch_run_count = 0
+
 -- Fire parameters (fire_columns-based, the best-performing mode)
 local fire_params = {
   base_heat = 200,
@@ -104,20 +150,22 @@ local function ensure_grid(w, h)
       grid[y][x] = 0
     end
   end
+  -- Fresh grid is all zeros ⇒ no live cells.
+  live_cells = 0
 end
 
+-- F3: thin wrappers kept for any external callers / tests. The hot
+-- update loop indexes the LUTs directly.
 local function heat_to_char(heat)
-  for _, entry in ipairs(heat_chars) do
-    if heat >= entry.threshold then return entry.char end
-  end
-  return " "
+  if heat < 0 then return heat_char_lut[0] end
+  if heat > 255 then return heat_char_lut[255] end
+  return heat_char_lut[heat]
 end
 
 local function heat_to_hl(heat)
-  for _, hl in ipairs(fire_hl_groups) do
-    if heat >= hl.threshold then return hl.name end
-  end
-  return "PowerModeFireBg"
+  if heat < 0 then return heat_hl_lut[0] end
+  if heat > 255 then return heat_hl_lut[255] end
+  return heat_hl_lut[heat]
 end
 
 --- Compute how many rows of fire should be visible based on combo level
@@ -196,26 +244,29 @@ local function seed_bottom_row()
 
   local level = math.min(current_combo_level or 0, 4)
   local max_heat = math.min(255, fire_params.base_heat + level * fire_params.heat_per_level)
+  local hot_lo = math.floor(max_heat * 0.7)
+  local cold_hi = math.floor(max_heat * 0.15)
 
+  local row = grid[grid_h]
+  local lc = live_cells
+  local llut = heat_live_lut
   for x = 1, grid_w do
+    local new_h
     if math.random() < fire_params.seed_density then
-      grid[grid_h][x] = utils.random_int(math.floor(max_heat * 0.7), max_heat)
+      new_h = utils.random_int(hot_lo, max_heat)
     else
-      grid[grid_h][x] = utils.random_int(0, math.floor(max_heat * 0.15))
+      new_h = utils.random_int(0, cold_hi)
     end
+    lc = lc + llut[new_h] - llut[row[x]]
+    row[x] = new_h
   end
+  live_cells = lc
 end
 
---- Check if the grid has any heat remaining
+--- Check if the grid has any heat remaining. O(1) — backed by the F4
+--- live_cells counter (heat > 5 mirrors the original predicate).
 local function grid_has_heat()
-  for y = 1, grid_h do
-    for x = 1, grid_w do
-      if grid[y] and grid[y][x] and grid[y][x] > 5 then
-        return true
-      end
-    end
-  end
-  return false
+  return live_cells > 0
 end
 
 --- Propagate heat upward and render to the floating window
@@ -262,24 +313,40 @@ function M.update(_dt)
     seed_bottom_row()
   end
 
-  -- Propagate: each cell = average of 3 cells below - random cooling
+  -- Propagate: each cell = average of 3 cells below - random cooling.
+  -- F4: incrementally update live_cells as cells cross the > 5 threshold
+  -- so the cooldown branch above stays O(1).
+  local llut = heat_live_lut
+  local lc = live_cells
+  local cooling = fire_params.cooling
   for y = 1, grid_h - 1 do
+    local row_dst = grid[y]
+    local row_src = grid[y + 1]
     for x = 1, grid_w do
-      local below = grid[y + 1][x]
-      local left = grid[y + 1][math.max(1, x - 1)]
-      local right = grid[y + 1][math.min(grid_w, x + 1)]
+      local below = row_src[x]
+      local left = row_src[x > 1 and (x - 1) or 1]
+      local right = row_src[x < grid_w and (x + 1) or grid_w]
       local avg = (below + left + right) / 3
-      local cool = utils.random_int(0, fire_params.cooling)
-      grid[y][x] = math.max(0, math.floor(avg - cool))
+      local cool = utils.random_int(0, cooling)
+      local new_h = math.max(0, math.floor(avg - cool))
+      lc = lc + llut[new_h] - llut[row_dst[x]]
+      row_dst[x] = new_h
     end
   end
 
   -- Cool the bottom row (faster during cooldown for visible fade)
   local cool_factor = cooling_down and 1.5 or 0.3
+  local bottom_cool_max = math.floor(cooling * cool_factor)
+  local bottom_row = grid[grid_h]
   for x = 1, grid_w do
-    local cool = utils.random_int(0, math.floor(fire_params.cooling * cool_factor))
-    grid[grid_h][x] = math.max(0, grid[grid_h][x] - cool)
+    local cool = utils.random_int(0, bottom_cool_max)
+    local was = bottom_row[x]
+    local new_h = was - cool
+    if new_h < 0 then new_h = 0 end
+    lc = lc + llut[new_h] - llut[was]
+    bottom_row[x] = new_h
   end
+  live_cells = lc
 
   -- Render only the bottom `visible_rows` of the heat grid to the buffer
   if not fire_buf or not vim.api.nvim_buf_is_valid(fire_buf) then return end
@@ -287,31 +354,70 @@ function M.update(_dt)
   local start_y = grid_h - visible_rows + 1
   clear_array(scratch_lines)
   local lines = scratch_lines
-  for y = start_y, grid_h do
+
+  -- F2 + F3: single pass per row produces both the concatenated row
+  -- string AND the per-row RLE'd highlight runs. Runs are accumulated
+  -- into scratch_runs (flat 4-tuple layout: row,start,end,hl) and
+  -- emitted as nvim_buf_set_extmark calls *after* nvim_buf_set_lines
+  -- so the buffer rows already exist by the time extmarks reference
+  -- them. All per-cell lookups go through the LUTs (no linear walks).
+  local runs = scratch_runs
+  local rc = 0
+  local clut = heat_char_lut
+  local hlut = heat_hl_lut
+  local llut_byte = heat_charlen_lut
+  for i = 1, visible_rows do
+    local y = start_y + i - 1
+    local row = grid[y]
     clear_array(scratch_row_chars)
     local row_chars = scratch_row_chars
+    local col_byte = 0
+    local run_hl = nil
+    local run_start = 0
+    local row_idx = i - 1
     for x = 1, grid_w do
-      row_chars[x] = heat_to_char(grid[y][x])
+      local h = row[x]
+      if h < 0 then h = 0 elseif h > 255 then h = 255 end
+      local hl = hlut[h]
+      row_chars[x] = clut[h]
+      if hl ~= run_hl then
+        if run_hl ~= nil and col_byte > run_start then
+          runs[rc + 1] = row_idx
+          runs[rc + 2] = run_start
+          runs[rc + 3] = col_byte
+          runs[rc + 4] = run_hl
+          rc = rc + 4
+        end
+        run_hl = hl
+        run_start = col_byte
+      end
+      col_byte = col_byte + llut_byte[h]
     end
-    lines[#lines + 1] = table.concat(row_chars)
+    if run_hl ~= nil and col_byte > run_start then
+      runs[rc + 1] = row_idx
+      runs[rc + 2] = run_start
+      runs[rc + 3] = col_byte
+      runs[rc + 4] = run_hl
+      rc = rc + 4
+    end
+    lines[i] = table.concat(row_chars)
   end
 
   pcall(vim.api.nvim_buf_set_lines, fire_buf, 0, -1, false, lines)
 
-  -- Apply per-cell highlights
   vim.api.nvim_buf_clear_namespace(fire_buf, fire_ns, 0, -1)
-  for i = 1, visible_rows do
-    local y = start_y + i - 1
-    local col_byte = 0
-    for x = 1, grid_w do
-      local heat = grid[y][x]
-      local hl = heat_to_hl(heat)
-      local ch = heat_to_char(heat)
-      local ch_len = #ch
-      pcall(vim.api.nvim_buf_add_highlight, fire_buf, fire_ns, hl, i - 1, col_byte, col_byte + ch_len)
-      col_byte = col_byte + ch_len
-    end
+  local set_extmark = vim.api.nvim_buf_set_extmark
+  for j = 1, rc, 4 do
+    pcall(set_extmark, fire_buf, fire_ns, runs[j], runs[j + 1], {
+      end_row = runs[j],
+      end_col = runs[j + 2],
+      hl_group = runs[j + 3],
+    })
   end
+  -- Nil out the run scratch tail to keep references from leaking past
+  -- the last live entry (matches the clear_array discipline elsewhere).
+  for j = rc + 1, scratch_run_count do runs[j] = nil end
+  scratch_run_count = rc
 end
 
 function M._hide_window()
@@ -364,6 +470,7 @@ function M.clear()
   grid = {}
   grid_w = 0
   grid_h = 0
+  live_cells = 0
 
   if fire_win and vim.api.nvim_win_is_valid(fire_win) then
     pcall(vim.api.nvim_win_close, fire_win, true)

--- a/lua/power-mode/renderer.lua
+++ b/lua/power-mode/renderer.lua
@@ -6,6 +6,23 @@ local M = {}
 
 local pool = {}
 
+-- F8: cache strdisplaywidth(char) per unique particle char. The particle
+-- alphabet across all presets is small and bounded (~30 chars), so the
+-- cache fills within the first frame of activity and is pure table
+-- lookup thereafter. strdisplaywidth is a vimscript bridge call that
+-- accounted for ~0.25 ms p50 in the latency micro-bench; skipping the
+-- bridge on cache hits is essentially free per-particle.
+local char_width_cache = {}
+local function get_char_width(ch)
+  local w = char_width_cache[ch]
+  if w == nil then
+    w = vim.fn.strdisplaywidth(ch)
+    if w < 1 then w = 1 end
+    char_width_cache[ch] = w
+  end
+  return w
+end
+
 function M.init()
   M.cleanup()
   local cfg = config.get()
@@ -26,7 +43,12 @@ function M.init()
       zindex = 50,
     })
     if ok then
-      pool[i] = { buf = buf, win = win, in_use = false }
+      -- F8: `was_in_use` tracks last-frame state so the offscreen-hide
+      -- loop only emits nvim_win_set_config for slots that were in use
+      -- last frame but aren't this frame. Pool size is 100 by default
+      -- and steady-state usage is ~10 slots; this avoids ~90 redundant
+      -- config writes per frame.
+      pool[i] = { buf = buf, win = win, in_use = false, was_in_use = false }
     end
   end
 end
@@ -35,8 +57,9 @@ function M.render(particles)
   local cfg = config.get()
   local avoid = cfg.particles.avoid_cursor
 
-  -- Mark all as unused
+  -- Mark all as unused (preserving the previous-frame state in was_in_use)
   for _, entry in ipairs(pool) do
+    entry.was_in_use = entry.in_use
     entry.in_use = false
   end
 
@@ -88,8 +111,7 @@ function M.render(particles)
     end
 
     pcall(vim.api.nvim_buf_set_lines, entry.buf, 0, -1, false, { p.char })
-    local char_width = vim.fn.strdisplaywidth(p.char)
-    if char_width < 1 then char_width = 1 end
+    local char_width = get_char_width(p.char)
     pcall(vim.api.nvim_win_set_config, entry.win, {
       relative = "editor",
       row = py,
@@ -108,9 +130,11 @@ function M.render(particles)
     ::continue::
   end
 
-  -- Hide unused windows offscreen
+  -- Hide windows that *were* visible last frame but aren't this frame.
+  -- Slots that have been parked offscreen since at least last frame
+  -- already have row=-10,col=-10 and don't need to be touched again.
   for _, entry in ipairs(pool) do
-    if not entry.in_use and vim.api.nvim_win_is_valid(entry.win) then
+    if entry.was_in_use and not entry.in_use and vim.api.nvim_win_is_valid(entry.win) then
       pcall(vim.api.nvim_win_set_config, entry.win, {
         relative = "editor",
         row = -10,

--- a/lua/power-mode/shake.lua
+++ b/lua/power-mode/shake.lua
@@ -5,24 +5,41 @@ local utils = require("power-mode.utils")
 
 local M = {}
 
+-- F6: single module-scope uv_timer reused across every scroll-shake
+-- event. Previously we allocated a new uv handle per shake event and
+-- closed it from the restore callback — at interval=1 under heavy
+-- typing that's 60+ open/close pairs per second of uv handle churn.
+-- Now we keep one handle for the lifetime of the plugin; `cleanup()`
+-- closes it when power-mode is disabled. We also coalesce overlapping
+-- shakes: while a restore is already pending, drop the new shake
+-- (prevents the visible "wobble" that compounding shakes produce and
+-- removes start/stop churn under storm typing).
 local shake_timer = nil
+local shake_restore_topline = nil  -- topline to restore to (set on shake start)
+local shake_pending = false        -- true while a restore is armed
 local keystroke_count = 0
 
 function M.trigger(level)
   local cfg = config.get()
-  if cfg.shake.mode == "none" then return end
+  local mode = cfg.shake.mode
+  if mode == "none" then return end
 
   keystroke_count = keystroke_count + 1
   if keystroke_count % cfg.shake.interval ~= 0 then return end
 
-  if cfg.shake.mode == "scroll" then
+  if mode == "scroll" then
     M._scroll_shake(level, cfg)
-  elseif cfg.shake.mode == "applescript" then
+  elseif mode == "applescript" then
     M._applescript_shake(level, cfg)
   end
 end
 
 function M._scroll_shake(_level, cfg)
+  -- Coalesce: while a previous shake's restore is still pending, drop
+  -- this event rather than restart the timer (would extend the visible
+  -- displacement window indefinitely under storm typing).
+  if shake_pending then return end
+
   local magnitude = cfg.shake.magnitude or 1
 
   -- Only manipulate topline — never touch cursor position
@@ -36,7 +53,9 @@ function M._scroll_shake(_level, cfg)
   -- Pick direction: shift topline up or down
   local dir = math.random() > 0.5 and magnitude or -magnitude
   local new_top = current_topline + dir
-  new_top = math.max(1, math.min(new_top, total_lines - win_height + 1))
+  if new_top < 1 then new_top = 1 end
+  local max_top = total_lines - win_height + 1
+  if new_top > max_top then new_top = max_top end
 
   -- Only shake if the shift actually moves the viewport
   if new_top == current_topline then return end
@@ -44,17 +63,19 @@ function M._scroll_shake(_level, cfg)
   -- Shift viewport only (no cursor manipulation)
   pcall(vim.fn.winrestview, { topline = new_top })
 
-  -- Cancel any previous pending restore
-  if shake_timer then
-    pcall(function() shake_timer:stop() shake_timer:close() end)
+  -- Lazily allocate the shared timer on first use.
+  if not shake_timer then
+    shake_timer = vim.loop.new_timer()
   end
-  shake_timer = vim.loop.new_timer()
+
+  shake_restore_topline = current_topline
+  shake_pending = true
   shake_timer:start(cfg.shake.restore_delay, 0, vim.schedule_wrap(function()
-    -- Restore only topline — cursor stays exactly where user left it
-    pcall(vim.fn.winrestview, { topline = current_topline })
-    if shake_timer then
-      pcall(function() shake_timer:stop() shake_timer:close() end)
-      shake_timer = nil
+    local restore_to = shake_restore_topline
+    shake_pending = false
+    shake_restore_topline = nil
+    if restore_to then
+      pcall(vim.fn.winrestview, { topline = restore_to })
     end
   end))
 end
@@ -87,6 +108,8 @@ function M.cleanup()
     pcall(function() shake_timer:stop() shake_timer:close() end)
     shake_timer = nil
   end
+  shake_pending = false
+  shake_restore_topline = nil
   keystroke_count = 0
 end
 


### PR DESCRIPTION
Draft follow-up to #8. Targets the largest *quantified* remaining cost: `fire_wall.update` (0.17–0.71 ms/frame, up to 22% CPU at 60 fps), plus shake timer churn and renderer residuals.

**Note**: stacked on `perf/optimisations` (PR #8) until that merges; base is `main` from the start so CI fires (PR #8 commits will appear in the diff until #8 merges).

### Tasks
- [ ] F0 bootstrap (this commit)
- [ ] F1 baseline measurement
- [ ] **Tier A — fire-wall** (`lua/power-mode/fire_wall.lua`)
  - [ ] F2 RLE'd extmark highlight runs (REPORT R1)
  - [ ] F3 Heat lookup precomputation (LUTs)
  - [ ] F4 Incremental `live_cells` tracking; dead-grid skip
  - [ ] F5 validate Tier A (gate before Tier B)
- [ ] **Tier B — shake** (`lua/power-mode/shake.lua`)
  - [ ] F6 Reuse `shake_timer`; coalesce overlapping shakes
  - [ ] F7 validate Tier B
- [ ] **Tier C — renderer residuals** (`lua/power-mode/renderer.lua`, revert if no gain)
  - [ ] F8 `strdisplaywidth` cache + hide-state tracking
  - [ ] F9 validate Tier C (keep-or-revert)
- [ ] F10 final regression-watch validation
- [ ] F11 `IMPROVEMENTS-2.md` + PR comment

### Discipline
Same honest-revert rule as #8 (R2 reverted when data didn't support it). Every task has a quantified pass criterion; misses get reverted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>