### PR TITLE
perf: make :PowerModeDisable near-instant

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           nvim --headless -u tests/minimal_init.lua -c "luafile tests/test_fire_wall.lua" -c "qall!"
 
+      - name: Run renderer tests
+        run: |
+          nvim --headless -u tests/minimal_init.lua -c "luafile tests/test_renderer.lua" -c "qall!"
+
   perf-smoke:
     # Non-asserting smoke run of the perf evaluation suite. Verifies that
     # every bench under tests/perf/ executes cleanly and produces valid

--- a/lua/power-mode/init.lua
+++ b/lua/power-mode/init.lua
@@ -192,10 +192,19 @@ function M.disable()
   engine.stop()
   particles.clear()
   fire.clear()
+
+  -- F9: suppress redraw and third-party autocmd cascades while deleting the
+  -- floating UI. See the 2026-08-08 disable latency benchmark.
+  local eventignore = vim.o.eventignore
+  local lazyredraw = vim.o.lazyredraw
+  vim.o.eventignore = "all"
+  vim.o.lazyredraw = true
   fire_wall.clear()
-  renderer.cleanup()
+  renderer.cleanup(true)
   combo.cleanup()
   shake.cleanup()
+  vim.o.eventignore = eventignore
+  vim.o.lazyredraw = lazyredraw
 
   vim.notify("Power Mode disabled", vim.log.levels.INFO)
 end

--- a/lua/power-mode/init.lua
+++ b/lua/power-mode/init.lua
@@ -18,6 +18,22 @@ local augroup = nil
 local stop_timer = nil
 local on_key_ns = nil
 
+local function with_ui_suppressed(fn)
+  local eventignore = vim.o.eventignore
+  local lazyredraw = vim.o.lazyredraw
+  vim.o.eventignore = "all"
+  vim.o.lazyredraw = true
+
+  local ok, err = pcall(fn)
+
+  vim.o.eventignore = eventignore
+  vim.o.lazyredraw = lazyredraw
+  if not ok then
+    vim.notify("[power-mode] disable teardown failed: " .. tostring(err), vim.log.levels.WARN)
+  end
+  return ok
+end
+
 local function get_cursor_pos()
   local cursor = vim.api.nvim_win_get_cursor(0)
   local pos = vim.fn.screenpos(vim.fn.win_getid(), cursor[1], cursor[2] + 1)
@@ -195,16 +211,12 @@ function M.disable()
 
   -- F9: suppress redraw and third-party autocmd cascades while deleting the
   -- floating UI. See the 2026-08-08 disable latency benchmark.
-  local eventignore = vim.o.eventignore
-  local lazyredraw = vim.o.lazyredraw
-  vim.o.eventignore = "all"
-  vim.o.lazyredraw = true
-  fire_wall.clear()
-  renderer.cleanup(true)
-  combo.cleanup()
-  shake.cleanup()
-  vim.o.eventignore = eventignore
-  vim.o.lazyredraw = lazyredraw
+  with_ui_suppressed(function()
+    fire_wall.clear()
+    renderer.cleanup(true)
+    combo.cleanup()
+    shake.cleanup()
+  end)
 
   vim.notify("Power Mode disabled", vim.log.levels.INFO)
 end

--- a/lua/power-mode/init.lua
+++ b/lua/power-mode/init.lua
@@ -9,6 +9,7 @@ local engine = require("power-mode.engine")
 local shake = require("power-mode.shake")
 local fire = require("power-mode.presets.fire")
 local fire_wall = require("power-mode.fire_wall")
+local utils = require("power-mode.utils")
 
 local M = {}
 
@@ -17,22 +18,6 @@ local _setup_called = false
 local augroup = nil
 local stop_timer = nil
 local on_key_ns = nil
-
-local function with_ui_suppressed(fn)
-  local eventignore = vim.o.eventignore
-  local lazyredraw = vim.o.lazyredraw
-  vim.o.eventignore = "all"
-  vim.o.lazyredraw = true
-
-  local ok, err = pcall(fn)
-
-  vim.o.eventignore = eventignore
-  vim.o.lazyredraw = lazyredraw
-  if not ok then
-    vim.notify("[power-mode] disable teardown failed: " .. tostring(err), vim.log.levels.WARN)
-  end
-  return ok
-end
 
 local function get_cursor_pos()
   local cursor = vim.api.nvim_win_get_cursor(0)
@@ -211,7 +196,7 @@ function M.disable()
 
   -- F9: suppress redraw and third-party autocmd cascades while deleting the
   -- floating UI. See the 2026-08-08 disable latency benchmark.
-  with_ui_suppressed(function()
+  utils.with_ui_suppressed("disable teardown", function()
     fire_wall.clear()
     renderer.cleanup(true)
     combo.cleanup()

--- a/lua/power-mode/renderer.lua
+++ b/lua/power-mode/renderer.lua
@@ -1,29 +1,15 @@
 --- Floating window pool renderer for neovim-power-mode
 --- Manages a pool of 1×1 floating windows for particle rendering
 local config = require("power-mode.config")
+local utils = require("power-mode.utils")
 
 local M = {}
 
 local pool = {}
 local cleanup_batch_size = 20
 
-local function with_ui_suppressed(fn)
-  local eventignore = vim.o.eventignore
-  local lazyredraw = vim.o.lazyredraw
-  vim.o.eventignore = "all"
-  vim.o.lazyredraw = true
-
-  local ok, err = pcall(fn)
-
-  vim.o.eventignore = eventignore
-  vim.o.lazyredraw = lazyredraw
-  if not ok then
-    vim.notify("[power-mode] renderer cleanup failed: " .. tostring(err), vim.log.levels.WARN)
-  end
-  return ok
-end
-
-M._with_ui_suppressed = with_ui_suppressed
+-- Test-only accessor for the shared UI-suppression helper.
+M._with_ui_suppressed = function(fn) return utils.with_ui_suppressed("renderer cleanup", fn) end
 
 -- F8: cache strdisplaywidth(char) per unique particle char. The particle
 -- alphabet across all presets is small and bounded (~30 chars), so the
@@ -73,7 +59,7 @@ function M.init()
 end
 
 local function cleanup_entries(entries, first, last)
-  with_ui_suppressed(function()
+  utils.with_ui_suppressed("renderer cleanup", function()
     for i = first, last do
       local entry = entries[i]
       if entry.buf and vim.api.nvim_buf_is_valid(entry.buf) then

--- a/lua/power-mode/renderer.lua
+++ b/lua/power-mode/renderer.lua
@@ -5,6 +5,7 @@ local config = require("power-mode.config")
 local M = {}
 
 local pool = {}
+local cleanup_batch_size = 20
 
 -- F8: cache strdisplaywidth(char) per unique particle char. The particle
 -- alphabet across all presets is small and bounded (~30 chars), so the
@@ -50,6 +51,35 @@ function M.init()
       -- config writes per frame.
       pool[i] = { buf = buf, win = win, in_use = false, was_in_use = false }
     end
+  end
+end
+
+local function cleanup_entries(entries, first, last)
+  local eventignore = vim.o.eventignore
+  local lazyredraw = vim.o.lazyredraw
+  vim.o.eventignore = "all"
+  vim.o.lazyredraw = true
+
+  for i = first, last do
+    local entry = entries[i]
+    if entry.buf and vim.api.nvim_buf_is_valid(entry.buf) then
+      pcall(vim.api.nvim_buf_delete, entry.buf, { force = true })
+    end
+    if entry.win and vim.api.nvim_win_is_valid(entry.win) then
+      pcall(vim.api.nvim_win_close, entry.win, true)
+    end
+  end
+
+  vim.o.eventignore = eventignore
+  vim.o.lazyredraw = lazyredraw
+end
+
+local function cleanup_deferred(entries, first)
+  if first > #entries then return end
+  cleanup_entries(entries, first, math.min(first + cleanup_batch_size - 1, #entries))
+  local next_entry = first + cleanup_batch_size
+  if next_entry <= #entries then
+    vim.schedule(function() cleanup_deferred(entries, next_entry) end)
   end
 end
 
@@ -146,16 +176,30 @@ function M.render(particles)
   end
 end
 
-function M.cleanup()
-  for _, entry in ipairs(pool) do
-    if entry.win and vim.api.nvim_win_is_valid(entry.win) then
-      pcall(vim.api.nvim_win_close, entry.win, true)
-    end
-    if entry.buf and vim.api.nvim_buf_is_valid(entry.buf) then
-      pcall(vim.api.nvim_buf_delete, entry.buf, { force = true })
-    end
-  end
+--- Reclaim the particle pool, optionally after parking visible slots.
+--- @param defer boolean|nil
+function M.cleanup(defer)
+  local old_pool = pool
   pool = {}
+
+  if defer then
+    -- F9: park the few visible slots before returning, then reclaim the old
+    -- pool in small batches. See the 2026-08-08 disable latency benchmark.
+    for _, entry in ipairs(old_pool) do
+      if entry.in_use and entry.win and vim.api.nvim_win_is_valid(entry.win) then
+        pcall(vim.api.nvim_win_set_config, entry.win, {
+          relative = "editor",
+          row = -10,
+          col = -10,
+          width = 1,
+          height = 1,
+        })
+      end
+    end
+    vim.schedule(function() cleanup_deferred(old_pool, 1) end)
+  else
+    cleanup_entries(old_pool, 1, #old_pool)
+  end
 end
 
 return M

--- a/lua/power-mode/renderer.lua
+++ b/lua/power-mode/renderer.lua
@@ -7,6 +7,24 @@ local M = {}
 local pool = {}
 local cleanup_batch_size = 20
 
+local function with_ui_suppressed(fn)
+  local eventignore = vim.o.eventignore
+  local lazyredraw = vim.o.lazyredraw
+  vim.o.eventignore = "all"
+  vim.o.lazyredraw = true
+
+  local ok, err = pcall(fn)
+
+  vim.o.eventignore = eventignore
+  vim.o.lazyredraw = lazyredraw
+  if not ok then
+    vim.notify("[power-mode] renderer cleanup failed: " .. tostring(err), vim.log.levels.WARN)
+  end
+  return ok
+end
+
+M._with_ui_suppressed = with_ui_suppressed
+
 -- F8: cache strdisplaywidth(char) per unique particle char. The particle
 -- alphabet across all presets is small and bounded (~30 chars), so the
 -- cache fills within the first frame of activity and is pure table
@@ -55,23 +73,17 @@ function M.init()
 end
 
 local function cleanup_entries(entries, first, last)
-  local eventignore = vim.o.eventignore
-  local lazyredraw = vim.o.lazyredraw
-  vim.o.eventignore = "all"
-  vim.o.lazyredraw = true
-
-  for i = first, last do
-    local entry = entries[i]
-    if entry.buf and vim.api.nvim_buf_is_valid(entry.buf) then
-      pcall(vim.api.nvim_buf_delete, entry.buf, { force = true })
+  with_ui_suppressed(function()
+    for i = first, last do
+      local entry = entries[i]
+      if entry.buf and vim.api.nvim_buf_is_valid(entry.buf) then
+        pcall(vim.api.nvim_buf_delete, entry.buf, { force = true })
+      end
+      if entry.win and vim.api.nvim_win_is_valid(entry.win) then
+        pcall(vim.api.nvim_win_close, entry.win, true)
+      end
     end
-    if entry.win and vim.api.nvim_win_is_valid(entry.win) then
-      pcall(vim.api.nvim_win_close, entry.win, true)
-    end
-  end
-
-  vim.o.eventignore = eventignore
-  vim.o.lazyredraw = lazyredraw
+  end)
 end
 
 local function cleanup_deferred(entries, first)

--- a/lua/power-mode/utils.lua
+++ b/lua/power-mode/utils.lua
@@ -25,6 +25,30 @@ function M.random_choice(list)
   return list[math.random(#list)]
 end
 
+--- F9: run `fn` with autocmds and redraws suppressed, always restoring the
+--- previous option values even if `fn` raises. Destroying the plugin's
+--- floating UI otherwise fires a WinClosed/BufDelete cascade into every
+--- subscribed third-party plugin and forces a redraw per window; leaving
+--- eventignore="all" behind on an error would silently break the editor.
+--- @param context string label used in the warning if `fn` fails
+--- @param fn function
+--- @return boolean ok
+function M.with_ui_suppressed(context, fn)
+  local eventignore = vim.o.eventignore
+  local lazyredraw = vim.o.lazyredraw
+  vim.o.eventignore = "all"
+  vim.o.lazyredraw = true
+
+  local ok, err = pcall(fn)
+
+  vim.o.eventignore = eventignore
+  vim.o.lazyredraw = lazyredraw
+  if not ok then
+    vim.notify("[power-mode] " .. context .. " failed: " .. tostring(err), vim.log.levels.WARN)
+  end
+  return ok
+end
+
 function M.get_editor_dimensions()
   return {
     width = vim.o.columns,

--- a/tests/test_renderer.lua
+++ b/tests/test_renderer.lua
@@ -15,6 +15,7 @@ local power_mode = require("power-mode")
 local combo = require("power-mode.combo")
 local fire_wall = require("power-mode.fire_wall")
 local renderer = require("power-mode.renderer")
+local shake = require("power-mode.shake")
 
 power_mode.disable()
 
@@ -87,6 +88,57 @@ vim.wait(1000, function()
 end)
 assert_eq(#vim.api.nvim_list_wins(), windows_before, "final disable restores window count")
 assert_eq(#vim.api.nvim_list_bufs(), buffers_before, "final disable restores buffer count")
+
+-- Test 3: disable restores UI options and warns if guarded teardown fails.
+power_mode.enable()
+original_eventignore = vim.o.eventignore
+original_lazyredraw = vim.o.lazyredraw
+vim.o.eventignore = "CursorHold"
+vim.o.lazyredraw = false
+local original_shake_cleanup = shake.cleanup
+local original_notify = vim.notify
+local disable_warning = nil
+shake.cleanup = function() error("forced disable cleanup failure") end
+vim.notify = function(message, level)
+  if level == vim.log.levels.WARN then disable_warning = message end
+end
+
+power_mode.disable()
+
+shake.cleanup = original_shake_cleanup
+vim.notify = original_notify
+assert_eq(vim.o.eventignore, "CursorHold", "failed disable restores eventignore")
+assert_eq(vim.o.lazyredraw, false, "failed disable restores lazyredraw")
+assert_eq(disable_warning and disable_warning:match("^%[power%-mode%]") ~= nil, true,
+  "failed disable emits prefixed warning")
+vim.wait(1000, function()
+  return resources_restored(windows_before, buffers_before)
+end)
+vim.o.eventignore = original_eventignore
+vim.o.lazyredraw = original_lazyredraw
+
+-- Test 4: renderer cleanup guard restores options and warns on failure.
+original_eventignore = vim.o.eventignore
+original_lazyredraw = vim.o.lazyredraw
+vim.o.eventignore = "CursorHold"
+vim.o.lazyredraw = false
+local renderer_warning = nil
+vim.notify = function(message, level)
+  if level == vim.log.levels.WARN then renderer_warning = message end
+end
+
+local renderer_ok = renderer._with_ui_suppressed(function()
+  error("forced renderer cleanup failure")
+end)
+
+vim.notify = original_notify
+assert_eq(renderer_ok, false, "renderer guard reports failure")
+assert_eq(vim.o.eventignore, "CursorHold", "failed renderer cleanup restores eventignore")
+assert_eq(vim.o.lazyredraw, false, "failed renderer cleanup restores lazyredraw")
+assert_eq(renderer_warning and renderer_warning:match("^%[power%-mode%]") ~= nil, true,
+  "failed renderer cleanup emits prefixed warning")
+vim.o.eventignore = original_eventignore
+vim.o.lazyredraw = original_lazyredraw
 
 print(string.format("\nRenderer tests: %d passed, %d failed", pass, fail))
 if fail > 0 then vim.cmd("cquit! 1") end

--- a/tests/test_renderer.lua
+++ b/tests/test_renderer.lua
@@ -24,6 +24,15 @@ local function resources_restored(windows, buffers)
     and #vim.api.nvim_list_bufs() == buffers
 end
 
+local function config_coord(value)
+  if type(value) == "number" then return value end
+  if type(value) ~= "table" then return nil end
+  -- Neovim 0.9 represents API floats as {[false] = value, [true] = exponent}.
+  if type(value[false]) == "number" then return value[false] end
+  if type(value[1]) == "number" then return value[1] end
+  return nil
+end
+
 -- Test 1: disable removes every plugin-created window and buffer.
 local windows_before = #vim.api.nvim_list_wins()
 local buffers_before = #vim.api.nvim_list_bufs()
@@ -35,9 +44,17 @@ power_mode.setup({
   fire_wall = { enabled = true },
 })
 power_mode.enable()
-combo.increment()
-fire_wall.spawn(2, 25)
-fire_wall.update(0)
+
+local pool_windows = {}
+for _, win in ipairs(vim.api.nvim_list_wins()) do
+  if win ~= vim.api.nvim_get_current_win() then
+    local cfg = vim.api.nvim_win_get_config(win)
+    if config_coord(cfg.row) == -10 and config_coord(cfg.col) == -10 then
+      pool_windows[#pool_windows + 1] = win
+    end
+  end
+end
+
 renderer.render({ {
   x = 20,
   y = 20,
@@ -46,6 +63,19 @@ renderer.render({ {
   max_lifetime = 200,
   color_idx = 1,
 } })
+
+local visible_particle_windows = {}
+for _, win in ipairs(pool_windows) do
+  local cfg = vim.api.nvim_win_get_config(win)
+  if config_coord(cfg.row) == 20 and config_coord(cfg.col) == 20 then
+    visible_particle_windows[#visible_particle_windows + 1] = win
+  end
+end
+assert_eq(#visible_particle_windows, 1, "captures the visible particle window")
+
+combo.increment()
+fire_wall.spawn(2, 25)
+fire_wall.update(0)
 local original_eventignore = vim.o.eventignore
 local original_lazyredraw = vim.o.lazyredraw
 vim.o.eventignore = "CursorHold"
@@ -53,10 +83,12 @@ vim.o.lazyredraw = false
 power_mode.disable()
 
 local all_particle_windows_parked = true
-for _, win in ipairs(vim.api.nvim_list_wins()) do
-  if win ~= vim.api.nvim_get_current_win() then
+for _, win in ipairs(visible_particle_windows) do
+  if vim.api.nvim_win_is_valid(win) then
     local cfg = vim.api.nvim_win_get_config(win)
-    if cfg.relative == "editor" and cfg.row ~= -10 then
+    local row = config_coord(cfg.row)
+    local col = config_coord(cfg.col)
+    if row ~= -10 and not (row == nil and col == -10) then
       all_particle_windows_parked = false
     end
   end

--- a/tests/test_renderer.lua
+++ b/tests/test_renderer.lua
@@ -1,0 +1,92 @@
+-- Tests for renderer teardown and disable cleanup
+local pass, fail = 0, 0
+
+local function assert_eq(actual, expected, name)
+  if actual == expected then
+    print("  PASS: " .. name)
+    pass = pass + 1
+  else
+    print("  FAIL: " .. name .. " (expected " .. tostring(expected) .. ", got " .. tostring(actual) .. ")")
+    fail = fail + 1
+  end
+end
+
+local power_mode = require("power-mode")
+local combo = require("power-mode.combo")
+local fire_wall = require("power-mode.fire_wall")
+local renderer = require("power-mode.renderer")
+
+power_mode.disable()
+
+local function resources_restored(windows, buffers)
+  return #vim.api.nvim_list_wins() == windows
+    and #vim.api.nvim_list_bufs() == buffers
+end
+
+-- Test 1: disable removes every plugin-created window and buffer.
+local windows_before = #vim.api.nvim_list_wins()
+local buffers_before = #vim.api.nvim_list_bufs()
+
+power_mode.setup({
+  auto_enable = false,
+  particles = { pool_size = 10, avoid_cursor = false },
+  combo = { enabled = true },
+  fire_wall = { enabled = true },
+})
+power_mode.enable()
+combo.increment()
+fire_wall.spawn(2, 25)
+fire_wall.update(0)
+renderer.render({ {
+  x = 20,
+  y = 20,
+  char = "*",
+  lifetime = 100,
+  max_lifetime = 200,
+  color_idx = 1,
+} })
+local original_eventignore = vim.o.eventignore
+local original_lazyredraw = vim.o.lazyredraw
+vim.o.eventignore = "CursorHold"
+vim.o.lazyredraw = false
+power_mode.disable()
+
+local all_particle_windows_parked = true
+for _, win in ipairs(vim.api.nvim_list_wins()) do
+  if win ~= vim.api.nvim_get_current_win() then
+    local cfg = vim.api.nvim_win_get_config(win)
+    if cfg.relative == "editor" and cfg.row ~= -10 then
+      all_particle_windows_parked = false
+    end
+  end
+end
+assert_eq(all_particle_windows_parked, true, "disable parks visible particle windows")
+assert_eq(vim.o.eventignore, "CursorHold", "disable restores eventignore")
+assert_eq(vim.o.lazyredraw, false, "disable restores lazyredraw")
+vim.wait(1000, function()
+  return resources_restored(windows_before, buffers_before)
+end)
+assert_eq(#vim.api.nvim_list_wins(), windows_before, "disable restores window count")
+assert_eq(#vim.api.nvim_list_bufs(), buffers_before, "disable restores buffer count")
+assert_eq(vim.o.eventignore, "CursorHold", "deferred cleanup restores eventignore")
+assert_eq(vim.o.lazyredraw, false, "deferred cleanup restores lazyredraw")
+vim.o.eventignore = original_eventignore
+vim.o.lazyredraw = original_lazyredraw
+
+-- Test 2: deferred cleanup cannot destroy a fresh pool after rapid re-enable.
+power_mode.enable()
+power_mode.disable()
+power_mode.enable()
+vim.wait(100, function() return false end)
+assert_eq(#vim.api.nvim_list_wins(), windows_before + 10, "rapid re-enable keeps fresh pool windows")
+assert_eq(#vim.api.nvim_list_bufs(), buffers_before + 10, "rapid re-enable keeps fresh pool buffers")
+
+power_mode.disable()
+vim.wait(1000, function()
+  return resources_restored(windows_before, buffers_before)
+end)
+assert_eq(#vim.api.nvim_list_wins(), windows_before, "final disable restores window count")
+assert_eq(#vim.api.nvim_list_bufs(), buffers_before, "final disable restores buffer count")
+
+print(string.format("\nRenderer tests: %d passed, %d failed", pass, fail))
+if fail > 0 then vim.cmd("cquit! 1") end


### PR DESCRIPTION
## Problem

`:PowerModeDisable` had a noticeable pause before the editor became usable again.

It was **not** waiting on anything — `disable()` was already fully synchronous with no fade-outs, no sleeps, and every timer properly `:stop()`+`:close()`. The cost was raw API work, and measurement placed almost all of it in one function.

## Measured root cause

`renderer.cleanup()` tore down the entire floating-window pool with a `nvim_win_close` + `nvim_buf_delete` per slot — 60 by default, up to 500. In a real tmux TUI that was **91.9% of total disable latency at the default pool size and 99.1% at max**. The cost splits roughly evenly between raw per-slot layout/redraw work and the `WinClosed`/`BufDelete` autocmd cascades fired into every subscribed third-party plugin. With five no-op subscribers of each, pool-500 teardown reached 32.6 ms.

Notably, pool windows were *opened* with `noautocmd = true` but closed with no such suppression.

Everything else on the path — timers, augroup deletion, `on_key` unregistration, fire wall, combo, shake, the notification — was individually negligible. Full per-step headless and TUI breakdown was captured during the work.

## Change

`disable()` still synchronously stops every input hook, timer and subsystem; only the visual reclamation moved.

- **Visible slots are parked offscreen before `disable()` returns**, so the effects vanish immediately.
- **The pool is detached rather than destroyed**, then reclaimed in scheduled batches of 20. Each batch is captured by its own closure rather than reading the module-level `pool`, so a fast disable → enable cycle cannot have an in-flight reclaim destroy the fresh pool. There is a regression test for exactly this race.
- **Buffers are deleted before windows**, since deleting a buffer displayed only in a minimal float closes the window implicitly — one destructive API call per slot instead of two. An explicit `nvim_win_close` remains as a stale-handle fallback.
- **`eventignore` and `lazyredraw` are suppressed** around all teardown, restored through an exception-safe helper (`utils.with_ui_suppressed`) so a throw mid-teardown can never strand the user with autocmds globally disabled or a frozen screen. Failures surface as a `[power-mode]` WARN rather than silently.

`M.init()` keeps synchronous cleanup semantics, so direct reinitialisation is unaffected.

## Results

p50 wall time, 25 runs after 5 warmups, Neovim 0.11.5 / macOS arm64:

| Mode | Pool | Autocmd load | Before | After | Speedup |
|---|---:|:---:|---:|---:|---:|
| Headless | 60 | no | 0.682 ms | 0.134 ms | 5.1x |
| Headless | 60 | yes | 1.173 ms | 0.130 ms | 9.0x |
| Headless | 500 | no | 26.560 ms | 0.345 ms | 76.9x |
| Headless | 500 | yes | 34.556 ms | 0.345 ms | 100.2x |
| tmux TUI | 60 | no | 0.608 ms | 0.039 ms | 15.7x |
| tmux TUI | 60 | yes | 0.916 ms | 0.058 ms | 15.8x |
| tmux TUI | 500 | no | 26.596 ms | 0.314 ms | 84.8x |
| tmux TUI | 500 | yes | 32.595 ms | 0.253 ms | 128.7x |

Post-return reclamation completes in 0.52-0.56 ms at pool 60 and 24.5-25.3 ms at pool 500, split across event-loop turns instead of blocking the editor as one operation.

## No functionality lost

All visuals, presets, combo, fire wall and shake behaviour are identical while enabled. `disable()` still fully restores the editor — tests assert window and buffer counts return to their pre-enable baseline, and that no timers, augroups or `on_key` handlers leak. The Neovim 0.9 floor is preserved (`vim.loop`, no `vim.uv`, no `table.clear`).

## Testing

- New `tests/test_renderer.lua` (18 assertions), registered in CI: immediate parking of visible slots, complete resource restoration, option restoration through both synchronous and deferred cleanup, exception-safe restore on a forced teardown failure, and the disable/enable race.
- Existing suites: 166 assertions across `config`, `particles`, `combo`, `highlights`, `fire_wall` — all pass.
- `bash tests/e2e/test_combo_hide.sh` — 3 passed.
- `PM_PERF_SMOKE=1 bash tests/perf/run.sh` — passes including the tmux TUI scenario.

## Rejected alternatives

- **Autocmd suppression + synchronous buffer-first deletion alone** — removed subscriber overhead but still left ~25 ms of raw reclamation at pool 500.
- **A single silent bulk `:bwipeout!`** — functionally correct but *slower*: TUI p50 regressed to 1.46 ms at pool 60 and 32.1 ms at pool 500.
- **Shrinking the default `pool_size`** — unnecessary once teardown was fixed, and it would have capped the maximum concurrent particle count.

## Residual risk

Reclamation is asynchronous, so detached scratch handles stay valid for roughly 0.5 ms (pool 60) to 25 ms (pool 500) after `disable()` returns. Visuals are hidden and all input hooks and timers are stopped before return, and the tests wait for and verify complete restoration.